### PR TITLE
Unit tests for com.depli.service.store.cache.*

### DIFF
--- a/src/test/java/com/depli/service/store/cache/BaseCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/BaseCacheServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.depli.service.store.cache;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringCache;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+public abstract class BaseCacheServiceImplTest<T> {
+
+    private static final String GET_CACHE = "getCache";
+    private static final String CLEAR_CACHE = "clearCache";
+
+    @Mock
+    private SpringEmbeddedCacheManager springEmbeddedCacheManager;
+
+    private Cache mockCache;
+    private SpringCache mockSpringCache;
+    private EmbeddedCacheManager mockEmbeddedCacheManager;
+    private T cacheService;
+    private String cacheKey;
+
+    @Before
+    public void setup() {
+        mockCache = mock(Cache.class);
+        mockEmbeddedCacheManager = mock(EmbeddedCacheManager.class);
+        mockSpringCache = mock(SpringCache.class);
+        cacheService = cacheService();
+        cacheKey = cacheKey();
+    }
+
+    @Test
+    public void getCache_WithGoodState_ShouldReturn() throws Exception {
+        baseGetCache();
+    }
+
+    @Test
+    public void clearCache_WithGoodState_ShouldClear() throws Exception {
+        baseClearCache();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void baseGetCache() throws Exception {
+        when(springEmbeddedCacheManager.getNativeCacheManager()).thenReturn(mockEmbeddedCacheManager);
+        when(mockEmbeddedCacheManager.getCache(cacheKey)).thenReturn(mockCache);
+
+        assertEquals(mockCache, invokeGetCache());
+    }
+
+    private void baseClearCache() throws Exception {
+        when(springEmbeddedCacheManager.getCache(cacheKey)).thenReturn(mockSpringCache);
+
+        invokeClearCache();
+
+        verify(mockSpringCache, times(1)).clear();
+    }
+
+    abstract protected T cacheService();
+    abstract protected String cacheKey();
+
+    private Cache invokeGetCache() throws Exception {
+        Method getCacheMethod = cacheService.getClass().getMethod(GET_CACHE);
+        return (Cache)getCacheMethod.invoke(cacheService);
+    }
+
+    private void invokeClearCache() throws Exception {
+        Method clearCacheMethod = cacheService.getClass().getMethod(CLEAR_CACHE);
+        clearCacheMethod.invoke(cacheService);
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/connector/impl/ConnectionTreeCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/connector/impl/ConnectionTreeCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.connector.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.connector.ConnectionTreeCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.CONNECTION_TREE_CACHE;
+
+public class ConnectionTreeCacheServiceImplTest extends BaseCacheServiceImplTest<ConnectionTreeCacheService> {
+
+    @InjectMocks
+    private ConnectionTreeCacheServiceImpl connectionTreeCacheService;
+
+    @Override
+    protected ConnectionTreeCacheService cacheService() {
+        return connectionTreeCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return CONNECTION_TREE_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/ClassLoadingDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/ClassLoadingDescriptorCacheServiceImplTest.java
@@ -1,0 +1,25 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.ClassLoadingDescriptorCacheService;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.CLASS_LOADING_DESCRIPTOR_CACHE;
+
+public class ClassLoadingDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<ClassLoadingDescriptorCacheService> {
+
+    @InjectMocks
+    private ClassLoadingDescriptorCacheServiceImpl classLoadingDescriptorCacheService;
+
+    @Override
+    protected ClassLoadingDescriptorCacheService cacheService() {
+        return classLoadingDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return CLASS_LOADING_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/MemoryDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/MemoryDescriptorCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.MemoryDescriptorCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.MEMORY_USAGE_DESCRIPTOR_CACHE;
+
+public class MemoryDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<MemoryDescriptorCacheService> {
+
+    @InjectMocks
+    private MemoryDescriptorCacheServiceImpl memoryDescriptorCacheService;
+
+    @Override
+    protected MemoryDescriptorCacheService cacheService() {
+        return memoryDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return MEMORY_USAGE_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/OperatingSystemDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/OperatingSystemDescriptorCacheServiceImplTest.java
@@ -1,0 +1,25 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.OperatingSystemDescriptorCacheService;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.OPERATING_SYSTEM_DESCRIPTOR_CACHE;
+
+public class OperatingSystemDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<OperatingSystemDescriptorCacheService> {
+
+    @InjectMocks
+    private OperatingSystemDescriptorCacheServiceImpl operatingSystemDescriptorCacheService;
+
+    @Override
+    protected OperatingSystemDescriptorCacheService cacheService() {
+        return operatingSystemDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return OPERATING_SYSTEM_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/PlatformResourcesDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/PlatformResourcesDescriptorCacheServiceImplTest.java
@@ -1,0 +1,25 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.PlatformResourcesDescriptorCacheService;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.PLATFORM_RESOURCES_DESCRIPTOR_CACHE;
+
+public class PlatformResourcesDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<PlatformResourcesDescriptorCacheService> {
+
+    @InjectMocks
+    private PlatformResourcesDescriptorCacheServiceImpl platformResourcesDescriptorCacheService;
+
+    @Override
+    protected PlatformResourcesDescriptorCacheService cacheService() {
+        return platformResourcesDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return PLATFORM_RESOURCES_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/RuntimeDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/RuntimeDescriptorCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.RuntimeDescriptorCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.RUNTIME_DESCRIPTOR_CACHE;
+
+public class RuntimeDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<RuntimeDescriptorCacheService> {
+
+    @InjectMocks
+    private RuntimeDescriptorCacheServiceImpl runtimeDescriptorCacheService;
+
+    @Override
+    protected RuntimeDescriptorCacheService cacheService() {
+        return runtimeDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return RUNTIME_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/descriptor/impl/ThreadDescriptorCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/descriptor/impl/ThreadDescriptorCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.descriptor.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.descriptor.ThreadDescriptorCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.THREAD_DESCRIPTOR_CACHE;
+
+public class ThreadDescriptorCacheServiceImplTest extends BaseCacheServiceImplTest<ThreadDescriptorCacheService> {
+
+    @InjectMocks
+    private ThreadDescriptorCacheServiceImpl threadDescriptorCacheService;
+
+    @Override
+    protected ThreadDescriptorCacheService cacheService() {
+        return threadDescriptorCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return THREAD_DESCRIPTOR_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/graph/impl/ClassLoadingGraphDataCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/graph/impl/ClassLoadingGraphDataCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.graph.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.graph.ClassLoadingGraphDataCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.CLASS_LOADING_GRAPH_DATA_CACHE;
+
+public class ClassLoadingGraphDataCacheServiceImplTest extends BaseCacheServiceImplTest<ClassLoadingGraphDataCacheService> {
+
+    @InjectMocks
+    private ClassLoadingGraphDataCacheServiceImpl classLoadingGraphDataCacheService;
+
+    @Override
+    protected ClassLoadingGraphDataCacheService cacheService() {
+        return classLoadingGraphDataCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return CLASS_LOADING_GRAPH_DATA_CACHE;
+    }
+
+}

--- a/src/test/java/com/depli/service/store/cache/graph/impl/ProcessingUnitGraphDataCacheServiceImplTest.java
+++ b/src/test/java/com/depli/service/store/cache/graph/impl/ProcessingUnitGraphDataCacheServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.depli.service.store.cache.graph.impl;
+
+import com.depli.service.store.cache.BaseCacheServiceImplTest;
+import com.depli.service.store.cache.graph.ProcessingUnitGraphDataCacheService;
+import org.mockito.InjectMocks;
+
+import static com.depli.constant.CacheName.CPU_GRAPH_DATA_CACHE;
+
+public class ProcessingUnitGraphDataCacheServiceImplTest extends BaseCacheServiceImplTest<ProcessingUnitGraphDataCacheService> {
+
+    @InjectMocks
+    private ProcessingUnitGraphDataCacheServiceImpl processingUnitGraphDataCacheService;
+
+    @Override
+    protected ProcessingUnitGraphDataCacheService cacheService() {
+        return processingUnitGraphDataCacheService;
+    }
+
+    @Override
+    protected String cacheKey() {
+        return CPU_GRAPH_DATA_CACHE;
+    }
+
+}


### PR DESCRIPTION
Contributing for #12 

Since the cache services are mostly duplicated code, I made a tradeoff between test readability and code duplication/boilerplate, i.e. there are common/default test cases in the base class that execute for the subclasses. Generally, subclassing for shared testing behavior is discouraged, but I don't think it's a big deal for this set of tests.