### PR TITLE
Adding coverage to connector package

### DIFF
--- a/src/main/java/com/depli/store/cache/connector/ConnectorFactory.java
+++ b/src/main/java/com/depli/store/cache/connector/ConnectorFactory.java
@@ -1,0 +1,11 @@
+package com.depli.store.cache.connector;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.HashMap;
+
+interface ConnectorFactory {
+    JMXConnector connect(JMXServiceURL jmxServiceURL, HashMap<String, Object> env)
+            throws IOException;
+}

--- a/src/main/java/com/depli/store/cache/connector/JMXConnectorFactory.java
+++ b/src/main/java/com/depli/store/cache/connector/JMXConnectorFactory.java
@@ -1,0 +1,14 @@
+package com.depli.store.cache.connector;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class JMXConnectorFactory implements ConnectorFactory {
+    @Override
+    public JMXConnector connect(JMXServiceURL jmxServiceURL, HashMap<String, Object> env)
+            throws IOException {
+        return javax.management.remote.JMXConnectorFactory.connect(jmxServiceURL, env);
+    }
+}

--- a/src/main/java/com/depli/store/cache/connector/MainConnector.java
+++ b/src/main/java/com/depli/store/cache/connector/MainConnector.java
@@ -1,12 +1,12 @@
 package com.depli.store.cache.connector;
 
 import com.depli.store.persistent.entity.JMXNode;
-import java.io.IOException;
-import java.util.HashMap;
+
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.HashMap;
 
 /**
  * Main connector
@@ -22,12 +22,14 @@ public class MainConnector {
   private JMXNode jmxNode;
   private JMXConnector jmxConnector;
   private MBeanServerConnection serverConnection;
+  private ConnectorFactory jmxFactory;
 
 
-  public MainConnector(JMXNode jmxNode) {
+  public MainConnector(JMXNode jmxNode, ConnectorFactory jmxFactory) {
     this.jmxNode = jmxNode;
     jmxConnector = null;
     serverConnection = null;
+    this.jmxFactory = jmxFactory;
   }
 
   public void openConnection() throws IOException {
@@ -42,9 +44,9 @@ public class MainConnector {
         String[] credentials = new String[]{jmxNode.getUsername(), jmxNode.getPassword()};
         env.put(JMXConnector.CREDENTIALS, credentials);
       }
-      jmxConnector = JMXConnectorFactory.connect(jmxServiceURL, env);
+      jmxConnector = jmxFactory.connect(jmxServiceURL, env);
     } else {
-      jmxConnector = JMXConnectorFactory.connect(jmxServiceURL, null);
+      jmxConnector = jmxFactory.connect(jmxServiceURL, null);
     }
 
     this.serverConnection = jmxConnector.getMBeanServerConnection();

--- a/src/main/java/com/depli/utility/connector/impl/ManagementBeanServerConnectorImpl.java
+++ b/src/main/java/com/depli/utility/connector/impl/ManagementBeanServerConnectorImpl.java
@@ -1,10 +1,12 @@
 package com.depli.utility.connector.impl;
 
+import com.depli.store.cache.connector.JMXConnectorFactory;
 import com.depli.store.cache.connector.MainConnector;
 import com.depli.store.persistent.entity.JMXNode;
 import com.depli.utility.connector.ManagementBeanServerConnector;
-import java.io.IOException;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 
 /**
@@ -19,7 +21,7 @@ public class ManagementBeanServerConnectorImpl implements ManagementBeanServerCo
 
   @Override
   public MainConnector getConnection(JMXNode jmxNode) throws IOException {
-    MainConnector mainConnector = new MainConnector(jmxNode);
+    MainConnector mainConnector = new MainConnector(jmxNode, new JMXConnectorFactory());
     mainConnector.openConnection();
 
     return mainConnector;

--- a/src/test/java/com/depli/store/cache/connector/MainConnectorTest.java
+++ b/src/test/java/com/depli/store/cache/connector/MainConnectorTest.java
@@ -1,0 +1,99 @@
+package com.depli.store.cache.connector;
+
+import com.depli.store.persistent.entity.JMXNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MainConnectorTest {
+
+    private JMXNode jmxNode;
+    private ConnectorFactory connectorFactory;
+    private MBeanServerConnection serverConnection;
+    private JMXConnector jmxConnector;
+    private MainConnector mainConnector;
+
+    @Before
+    public void setup() {
+        this.jmxNode = mock(JMXNode.class);
+        this.connectorFactory = mock(ConnectorFactory.class);
+    }
+
+    @Test
+    public void openConnectionSetsServerConnectionWhenConnectDoesNotFails()
+            throws IOException {
+        givenServerConnection();
+        givenJmxConnector();
+        givenUnfailingConnection();
+        givenMainConnector(jmxNode, connectorFactory);
+
+        whenConnectionIsOpen(mainConnector);
+
+        assertEquals(serverConnection, mainConnector.getServerConnection());
+    }
+
+    @Test
+    public void openConnectionRequiringAuthConnectionDoesntFails()
+            throws IOException {
+        givenServerConnection();
+        givenJmxConnector();
+        givenUnfailingConnection();
+        givenAuthIsRequired();
+        givenMainConnector(jmxNode, connectorFactory);
+
+        whenConnectionIsOpen(mainConnector);
+
+        assertEquals(serverConnection, mainConnector.getServerConnection());
+    }
+
+    private void givenAuthIsRequired() {
+        when(jmxNode.isAuthRequired()).thenReturn(Boolean.TRUE);
+    }
+
+    @Test(expected = IOException.class)
+    public void openConnectionFailsOnConnectorFactoryConnectionFailure()
+            throws IOException {
+        givingFailingConnection();
+        givenMainConnector(jmxNode, connectorFactory);
+
+        whenConnectionIsOpen(mainConnector);
+    }
+
+    private void givingFailingConnection()
+            throws IOException {
+        when(connectorFactory.connect(any(), any())).thenThrow(IOException.class);
+    }
+
+    private void whenConnectionIsOpen(MainConnector mainConnector)
+            throws IOException {
+        mainConnector.openConnection();
+    }
+
+    private void givenMainConnector(JMXNode jmxNode, ConnectorFactory connectorFactory) {
+        this.mainConnector = new MainConnector(jmxNode, connectorFactory);
+    }
+
+    private void givenUnfailingConnection()
+            throws IOException {
+        when(connectorFactory.connect(any(), any())).thenReturn(jmxConnector);
+    }
+
+    private void givenServerConnection() {
+        this.serverConnection = mock(MBeanServerConnection.class);
+    }
+
+    private void givenJmxConnector()
+            throws IOException {
+        this.jmxConnector = mock(JMXConnector.class);
+        when(jmxConnector.getMBeanServerConnection()).thenReturn(serverConnection);
+    }
+
+}


### PR DESCRIPTION
Contributing for #12

A refactor was made to class com.depli.store.cache.connector.MainConnector accepting a connector factory thus replacing the call to static method javax.management.remote.JMXConnectorFactory#connect(javax.management.remote.JMXServiceURL, java.util.Map<java.lang.String,?>) 